### PR TITLE
feat: 添加对Air4 Pro的支持

### DIFF
--- a/DeviceCapabilities.cs
+++ b/DeviceCapabilities.cs
@@ -31,7 +31,7 @@ public class DeviceCapabilities
     private static readonly HashSet<string> SpatialAudioModels = new() { "encox3" };
     private static readonly HashSet<string> SpatialSoundModels = new() { "encofree4", "encoair5" };
     private static readonly HashSet<string> LegacyAncModels   = new() { "encoair2pro" };
-    private static readonly HashSet<string> DualDeviceModels  = new() { "encofree4", "encox3" };
+    private static readonly HashSet<string> DualDeviceModels  = new() { "encofree4", "encox3", "encoair4pro" };
 
     // X3 大师调音（5种，与欢律一致）
     private static readonly Dictionary<string, byte> X3Eq = new()
@@ -51,6 +51,14 @@ public class DeviceCapabilities
         ["澎湃低音"] = 2,
         ["丹拿特调"] = 3,
         ["活力动感"] = 7,
+    };
+
+    // Air4 Pro 调音 (实测)
+    private static readonly Dictionary<string, byte> Air4ProEq = new()
+    {
+        ["纯粹原音"] = 0,
+        ["脉冲低音"] = 1,
+        ["悠扬人声"] = 2,
     };
 
     // ============================================================
@@ -75,6 +83,7 @@ public class DeviceCapabilities
         "OPPO Enco X3"       => DetectByNorm("encox3", "OPPO Enco X3"),
         "OPPO Enco Air5"     => DetectByNorm("encoair5", "OPPO Enco Air5"),
         "OPPO Enco Air2 Pro" => DetectByNorm("encoair2pro", "OPPO Enco Air2 Pro"),
+        "OPPO Enco Air4 Pro" => DetectByNorm("encoair4pro", "OPPO Enco Air4 Pro"),
         _                    => Default()
     };
 
@@ -105,6 +114,11 @@ public class DeviceCapabilities
         {
             caps.EqPresets = Free4Eq;   // Air5 与 Free4 一致
             caps.ModelName = "OPPO Enco Air5";
+        }
+        else if (Match(norm, "encoair4pro"))
+        {
+            caps.EqPresets = Air4ProEq;
+            caps.ModelName = "OPPO Enco Air4 Pro";
         }
         else if (Match(norm, "encoair2pro"))
         {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -113,6 +113,7 @@ public partial class MainWindow : Wpf.Ui.Controls.FluentWindow
         CbModel.Items.Add("OPPO Enco Free4");
         CbModel.Items.Add("OPPO Enco X3");
         CbModel.Items.Add("OPPO Enco Air5");
+        CbModel.Items.Add("OPPO Enco Air4 Pro");
         CbModel.Items.Add("OPPO Enco Air2 Pro");
         _modelOverride = ReadRegStr(AppConst.RegBase, "ModelOverride");
         CbModel.SelectedItem = _modelOverride ?? "自动检测";

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## English
 
-Windows desktop OPPO earbuds Bluetooth controller, supporting Enco Free4 / X3 / Air5 / Air2 Pro series.
+Windows desktop OPPO earbuds Bluetooth controller, supporting Enco Free4 / X3 / Air4 Pro /Air5 / Air2 Pro series.
 
 > **Only OPPO Enco Free4 has been fully tested — all features work correctly.** Other models' adaptation logic is ported from open-source reference projects and has not been verified on real devices. Full functionality is not guaranteed.
 
@@ -63,6 +63,7 @@ dotnet publish -c Release -r win-x64 -o publish
 | Enco Free4 | ✅ | ✅ | ✅ | —  | ✅ | 5 presets |
 | Enco X3    | ✅ | —  | —  | ✅ | ✅ | 5 presets |
 | Enco Air5  | ✅ | —  | ✅ | —  | —  | 5 presets |
+| Enco Air4 Pro | ✅ | —  | — | — | ✅ | 3 presets |
 | Enco Air2 Pro | ✅ | —  | —  | —  | —  | 5 presets |
 
 Other Bluetooth devices whose name contains "OPPO" will auto-connect with a generic feature set.
@@ -96,7 +97,7 @@ GPL-3.0
 
 ## 中文
 
-Windows 桌面端 OPPO 耳机蓝牙控制器，支持 Enco Free4 / X3 / Air5 / Air2 Pro 系列。
+Windows 桌面端 OPPO 耳机蓝牙控制器，支持 Enco Free4 / X3 / Air4 Pro / Air5 / Air2 Pro 系列。
 
 > **当前仅完整测试过 OPPO Enco Free4，功能均正常。** 其他机型适配逻辑移植自开源参考项目，未做真机验证，不保证全部功能可用。
 
@@ -153,6 +154,7 @@ dotnet publish -c Release -r win-x64 -o publish
 | Enco Free4 | ✅ | ✅ | ✅ | — | ✅ | 5 种 |
 | Enco X3 | ✅ | — | — | ✅ | ✅ | 5 种 |
 | Enco Air5 | ✅ | — | ✅ | — | — | 5 种 |
+| Enco Air4 Pro | ✅ | —  | — | — | ✅ | 3 种 |
 | Enco Air2 Pro | ✅ | — | — | — | — | 5 种 |
 
 其他名称包含 "OPPO" 的蓝牙设备可自动连接，使用通用功能集。


### PR DESCRIPTION
增加了Air4 Pro的配置， 对照欢律添加了Air4 Pro的 `Air4ProEq` 
`纯粹原音` (0) / `脉冲低音` (1) / `悠扬人声` (2)
文档更新

添加后主程序可以正常跑，UI没问题
我的Air4 Pro正常切换降噪、EQ、双设备、游戏模式（需要开启兼容游戏模式）

方便自用，也希望能方便下大家
