### PR TITLE
json更新

### DIFF
--- a/DeviceModels.json
+++ b/DeviceModels.json
@@ -3,6 +3,1294 @@
     "rssi": {
       "rightOffset": 0,
       "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "minVersion": 16007000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 2
+        }
+      ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "minSelectCount": 1,
+          "action": 11,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "multiDevicesConnect": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Air4s",
+    "id": "06F010",
+    "type": "T1",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 16003000,
+    "children": [
+      {
+        "name": "OPPO Enco xiapu OF"
+      }
+    ],
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154529,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "collectLogs": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0,
+          "defaultFunction": 262144
+        }
+      ],
+      "holdInBoxPairing": 1,
+      "batteryInfo": 1,
+      "promptVolume": 1,
+      "openBoxPairing": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "firmwareTrack": 1,
+      "equalizer": 3,
+      "controlGuideSupport": 1,
+      "multiDevicesConnect": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 22,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 31,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 32,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "aiTranslate": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco R5",
+    "id": "06B450",
+    "type": "T2",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 16001000,
+    "function": {
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds Air8",
+    "supportRlmDeviceFunction": true,
+    "id": "066812",
+    "protocolType": 1,
+    "type": "T1",
+    "supportSpp": true,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "minVersion": 16006000,
+    "children": [
+      {
+        "name": "OnePlus Nord Buds Laplace 4"
+      }
+    ],
+    "function": {
+      "strongNoiseReductionRealTime": 1,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "whiteNoise": 1,
+      "meetingAssistant": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7,
+              "intellectNoiseReductionSummary": 1
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "weakNoiseReductionSummary": 1,
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "customEqUiVersion": 2,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "collectLogs": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "promptVolumeRange": {
+        "min": 2,
+        "max": 10
+      },
+      "feedback": 1,
+      "firmwareTrack": 1,
+      "related": 1,
+      "equalizer": 4,
+      "longPressType": 8833,
+      "multiDevicesConnect": 2,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "cleanGuide": 1,
+      "multiConnectFunctions": [
+        {
+          "minFirmVersion": 0,
+          "functionType": "displayPairedDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "connectDisconnectDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "unpairDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "setPriorityDevice"
+        }
+      ],
+      "swiftPair": 1,
+      "functionIntroductionGuide": 1,
+      "spatialDescriptionType": 4,
+      "upgradeMtu": 1,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154531,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 0
+        }
+      ],
+      "customEqFrequency": [
+        31,
+        62,
+        125,
+        250,
+        500,
+        1000,
+        2000,
+        4000,
+        8000,
+        16000
+      ],
+      "gameSoundMutexes": [
+        1,
+        2
+      ],
+      "promptVolume": 1,
+      "autoBTBond": 1,
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "voiceWake": 3,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "firmwareFileCheckFlags": 7,
+      "aiTranslate": 1,
+      "gameSoundList": [
+        {
+          "type": 3
+        },
+        {
+          "type": 0
+        }
+      ],
+      "introductionGuideList": [
+        2,
+        1,
+        3,
+        9,
+        6,
+        7,
+        5,
+        11
+      ],
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus Flow Buds",
+    "id": "067414",
+    "type": "T1",
+    "supportSpp": true,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "minVersion": 16006000,
+    "children": [
+      {
+        "name": "OPPO Enco Laplace 3"
+      }
+    ],
+    "function": {
+      "strongNoiseReductionRealTime": 1,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "whiteNoise": 1,
+      "meetingAssistant": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7,
+              "intellectNoiseReductionSummary": 1
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "weakNoiseReductionSummary": 1,
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "customEqUiVersion": 2,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "collectLogs": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "promptVolumeRange": {
+        "min": 2,
+        "max": 10
+      },
+      "feedback": 1,
+      "firmwareTrack": 1,
+      "related": 1,
+      "equalizer": 4,
+      "longPressType": 8833,
+      "multiDevicesConnect": 2,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "cleanGuide": 1,
+      "multiConnectFunctions": [
+        {
+          "minFirmVersion": 0,
+          "functionType": "displayPairedDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "connectDisconnectDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "unpairDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "setPriorityDevice"
+        }
+      ],
+      "swiftPair": 1,
+      "functionIntroductionGuide": 1,
+      "spatialDescriptionType": 2,
+      "upgradeMtu": 1,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154531,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 0
+        }
+      ],
+      "customEqFrequency": [
+        31,
+        62,
+        125,
+        250,
+        500,
+        1000,
+        2000,
+        4000,
+        8000,
+        16000
+      ],
+      "gameSoundMutexes": [
+        1,
+        2
+      ],
+      "promptVolume": 1,
+      "autoBTBond": 1,
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "voiceWake": 3,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 26,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 28,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 29,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "firmwareFileCheckFlags": 7,
+      "aiTranslate": 1,
+      "gameSoundList": [
+        {
+          "type": 3
+        },
+        {
+          "type": 0
+        }
+      ],
+      "introductionGuideList": [
+        2,
+        1,
+        3,
+        9,
+        6,
+        7,
+        5,
+        11
+      ],
+      "bassEngineSupport": 1
+    },
+    "name": "OPPO Enco Air5s（星光版）",
+    "id": "06E810",
+    "type": "T1",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "minVersion": 16006000,
+    "children": [
+      {
+        "name": "OPPO Enco Laplace 1"
+      },
+      {
+        "name": "OPPO Enco Laplace 2"
+      }
+    ],
+    "function": {
+      "strongNoiseReductionRealTime": 1,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "whiteNoise": 1,
+      "meetingAssistant": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7,
+              "intellectNoiseReductionSummary": 1
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "weakNoiseReductionSummary": 1,
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "customEqUiVersion": 2,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "collectLogs": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "promptVolumeRange": {
+        "min": 2,
+        "max": 10
+      },
+      "feedback": 1,
+      "firmwareTrack": 1,
+      "related": 1,
+      "equalizer": 4,
+      "longPressType": 8833,
+      "multiDevicesConnect": 2,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "cleanGuide": 1,
+      "multiConnectFunctions": [
+        {
+          "minFirmVersion": 0,
+          "functionType": "displayPairedDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "connectDisconnectDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "unpairDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "setPriorityDevice"
+        }
+      ],
+      "swiftPair": 1,
+      "functionIntroductionGuide": 1,
+      "spatialDescriptionType": 2,
+      "upgradeMtu": 1,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154531,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 0
+        }
+      ],
+      "customEqFrequency": [
+        31,
+        62,
+        125,
+        250,
+        500,
+        1000,
+        2000,
+        4000,
+        8000,
+        16000
+      ],
+      "gameSoundMutexes": [
+        1,
+        2
+      ],
+      "promptVolume": 1,
+      "autoBTBond": 1,
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "voiceWake": 3,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 26,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 28,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 29,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "firmwareFileCheckFlags": 7,
+      "aiTranslate": 1,
+      "gameSoundList": [
+        {
+          "type": 3
+        },
+        {
+          "type": 0
+        }
+      ],
+      "introductionGuideList": [
+        2,
+        1,
+        3,
+        9,
+        6,
+        7,
+        5,
+        11
+      ],
+      "bassEngineSupport": 1
+    },
+    "name": "OPPO Enco Air5s",
+    "id": "06C810",
+    "type": "T1",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 54,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "minVersion": 16006002,
+    "children": [
+      {
+        "name": "OnePlus Nord Buds ohm EX"
+      }
+    ],
+    "function": {
+      "strongNoiseReductionRealTime": 1,
+      "fitDetection": 1,
+      "dolbyAtmos": 1,
+      "whiteNoise": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "customEqUiVersion": 2,
+      "newFunctionGuide": 0,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "collectLogs": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "related": 1,
+      "equalizer": 4,
+      "longPressType": 8833,
+      "multiDevicesConnect": 2,
+      "customEqualizer": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1,
+      "cleanGuide": 1,
+      "multiConnectFunctions": [
+        {
+          "minFirmVersion": 0,
+          "functionType": "displayPairedDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "connectDisconnectDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "unpairDevice"
+        }
+      ],
+      "swiftPair": 1,
+      "spatialDescriptionType": 4,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 1057377,
+          "showEar": 0
+        },
+        {
+          "entryStrModify": [
+            {
+              "categoryVersion": 2
+            }
+          ],
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 0
+        }
+      ],
+      "customEqFrequency": [
+        31,
+        62,
+        125,
+        250,
+        500,
+        1000,
+        2000,
+        4000,
+        8000,
+        16000
+      ],
+      "gameSoundMutexes": [
+        1
+      ],
+      "promptVolume": 1,
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 2
+        }
+      ],
+      "earScan": 1,
+      "findDevice": 1,
+      "aiTranslate": 1,
+      "gameSoundList": [
+        {
+          "type": 3
+        },
+        {
+          "type": 0
+        }
+      ],
+      "bassEngineSupport": 1,
+      "introductionGuideList": [
+        2,
+        1,
+        3,
+        9,
+        6,
+        7,
+        5
+      ]
+    },
+    "name": "OnePlus Nord Buds 4",
+    "id": "067014",
+    "type": "T1",
+    "supportSpp": true,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 52,
+      "firstRssi": 49,
+      "flattenOffset": 2
+    },
+    "minVersion": 16005000,
+    "children": [
+      {
+        "name": "OPPO Enco Nobel"
+      }
+    ],
+    "function": {
+      "aiSummaryToneSource": 1,
+      "highToneQuality": 1,
+      "wearingVideoTutorial": 1,
+      "meetingAssistant": 1,
+      "whiteNoise": 1,
+      "customDress": 1,
+      "collectLogs": 1,
+      "pairingModeTip": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 30,
+          "support": 131584,
+          "showEar": 0
+        }
+      ],
+      "firmwareTrack": 1,
+      "related": 1,
+      "equalizer": 4,
+      "aiSummary": 1,
+      "multiDevicesConnect": 2,
+      "carouselDress": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1,
+      "minOtaBattery": 30,
+      "pairingInBoxCount": 1,
+      "multiConnectFunctions": [
+        {
+          "minFirmVersion": 0,
+          "functionType": "displayPairedDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "connectDisconnectDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "unpairDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "setPriorityDevice"
+        }
+      ],
+      "swiftPair": 1,
+      "functionIntroductionGuide": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "voiceCommandItems": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        9,
+        10
+      ],
+      "deviceLostRemind": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 1057403,
+          "showEar": 0
+        },
+        {
+          "entryStrModify": [
+            {
+              "summaryVersion": 2,
+              "targetFunction": 1024
+            }
+          ],
+          "ear": 2,
+          "action": 5,
+          "support": 1536,
+          "showEar": 0
+        }
+      ],
+      "voiceCommand": 2,
+      "promptVolume": 1,
+      "spatialHiResMutex": 1,
+      "autoBTBond": 1,
+      "wearDetection": 1,
+      "aiClearCall": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "controlAutoVolumeSupport": 1,
+      "voiceWake": 3,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "brLeCoexist": 1,
+      "equalizerMode": [
+        {
+          "modeType": 26,
+          "summaryId": 6,
+          "tag": 3,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 34,
+          "summaryId": 7,
+          "tag": 3,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 28,
+          "summaryId": 3,
+          "tag": 3,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 30,
+          "summaryId": 5,
+          "tag": 3,
+          "protocolIndex": 4
+        }
+      ],
+      "findDevice": 1,
+      "tutorialGuide": 1,
+      "firmwareFileCheckFlags": 7,
+      "aiTranslate": 1,
+      "incomingCallControl": 0,
+      "introductionGuideList": [
+        2,
+        1,
+        6,
+        12,
+        13,
+        15,
+        5
+      ]
+    },
+    "name": "OPPO Enco Clip2",
+    "id": "06E010",
+    "type": "O1",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
       "secondRssi": 54,
       "firstRssi": 54,
       "flattenOffset": 2
@@ -448,6 +1736,4665 @@
     "rssi": {
       "rightOffset": 0,
       "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "minVersion": 16003000,
+    "children": [
+      {
+        "name": "OnePlus Nord Buds Einstein 1"
+      }
+    ],
+    "function": {
+      "highToneQuality": 1,
+      "whiteNoise": 1,
+      "meetingAssistant": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "customEqUiVersion": 2,
+      "collectLogs": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0
+        }
+      ],
+      "promptVolumeRange": {
+        "min": 2,
+        "max": 10
+      },
+      "feedback": 1,
+      "equalizer": 4,
+      "diagnostic": 1,
+      "cleanGuide": 1,
+      "multiConnectFunctions": [
+        {
+          "minFirmVersion": 0,
+          "functionType": "displayPairedDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "connectDisconnectDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "unpairDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "setPriorityDevice"
+        }
+      ],
+      "functionIntroductionGuide": 1,
+      "spatialDescriptionType": 4,
+      "upgradeMtu": 1,
+      "spatialHiResMutex": 1,
+      "voiceWake": 3,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "gameSoundList": [
+        {
+          "type": 3
+        },
+        {
+          "type": 0
+        }
+      ],
+      "bassEngineSupport": 1,
+      "strongNoiseReductionRealTime": 1,
+      "fitDetection": 1,
+      "dolbyAtmos": 1,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "batteryInfo": 1,
+      "firmwareTrack": 1,
+      "related": 1,
+      "longPressType": 8833,
+      "multiDevicesConnect": 2,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "swiftPair": 1,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154529,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 0
+        }
+      ],
+      "customEqFrequency": [
+        31,
+        62,
+        125,
+        250,
+        500,
+        1000,
+        2000,
+        4000,
+        8000,
+        16000
+      ],
+      "gameSoundMutexes": [
+        1,
+        2,
+        3
+      ],
+      "promptVolume": 1,
+      "autoBTBond": 1,
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "firmwareFileCheckFlags": 7,
+      "aiTranslate": 1,
+      "introductionGuideList": [
+        2,
+        1,
+        3,
+        9,
+        7,
+        5
+      ]
+    },
+    "name": "OnePlus Buds Ace 3",
+    "id": "066414",
+    "type": "T1",
+    "supportSpp": true,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "minVersion": 16003000,
+    "children": [
+      {
+        "name": "OnePlus Nord Buds Einstein 2"
+      }
+    ],
+    "function": {
+      "highToneQuality": 1,
+      "whiteNoise": 1,
+      "meetingAssistant": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "customEqUiVersion": 2,
+      "collectLogs": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0
+        }
+      ],
+      "promptVolumeRange": {
+        "min": 2,
+        "max": 10
+      },
+      "feedback": 1,
+      "equalizer": 4,
+      "diagnostic": 1,
+      "cleanGuide": 1,
+      "multiConnectFunctions": [
+        {
+          "minFirmVersion": 0,
+          "functionType": "displayPairedDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "connectDisconnectDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "unpairDevice"
+        },
+        {
+          "minFirmVersion": 0,
+          "functionType": "setPriorityDevice"
+        }
+      ],
+      "functionIntroductionGuide": 1,
+      "spatialDescriptionType": 4,
+      "upgradeMtu": 1,
+      "spatialHiResMutex": 1,
+      "voiceWake": 3,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "gameSoundList": [
+        {
+          "type": 3
+        },
+        {
+          "type": 0
+        }
+      ],
+      "bassEngineSupport": 1,
+      "strongNoiseReductionRealTime": 1,
+      "fitDetection": 1,
+      "dolbyAtmos": 1,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "batteryInfo": 1,
+      "firmwareTrack": 1,
+      "related": 1,
+      "longPressType": 8833,
+      "multiDevicesConnect": 2,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "swiftPair": 1,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154529,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 0
+        }
+      ],
+      "customEqFrequency": [
+        31,
+        62,
+        125,
+        250,
+        500,
+        1000,
+        2000,
+        4000,
+        8000,
+        16000
+      ],
+      "gameSoundMutexes": [
+        1,
+        2,
+        3
+      ],
+      "promptVolume": 1,
+      "autoBTBond": 1,
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "firmwareFileCheckFlags": 7,
+      "aiTranslate": 1,
+      "introductionGuideList": [
+        2,
+        1,
+        3,
+        9,
+        7,
+        5
+      ]
+    },
+    "name": "OnePlus Nord Buds 4 Pro",
+    "id": "066814",
+    "type": "T1",
+    "supportSpp": true,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 59,
+      "firstRssi": 56,
+      "flattenOffset": 0
+    },
+    "minVersion": 15010000,
+    "children": [
+      {
+        "name": "OnePlus Nord Curie DO"
+      }
+    ],
+    "function": {
+      "dolbyAtmos": 1,
+      "customDress": 1,
+      "collectLogs": 1,
+      "firmwareCheckCommandId": 0,
+      "pairingModeTip": 5,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0,
+          "defaultFunction": 262144
+        }
+      ],
+      "holdInBoxPairing": 1,
+      "batteryInfo": 1,
+      "openBoxPairing": 1,
+      "related": 1,
+      "firmwareTrack": 1,
+      "equalizer": 4,
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "spatialDescriptionType": 4,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154529,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "gameSoundMutexes": [
+        1
+      ],
+      "promptVolume": 1,
+      "fastDiscovery": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "aiTranslate": 1,
+      "gameSoundList": [
+        {
+          "type": 3
+        },
+        {
+          "type": 0
+        }
+      ]
+    },
+    "name": "OnePlus Buds 3V",
+    "id": "066054",
+    "type": "T2",
+    "supportSpp": true,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 59,
+      "firstRssi": 56,
+      "flattenOffset": 0
+    },
+    "minVersion": 15007000,
+    "children": [
+      {
+        "name": "OnePlus Nord Curie"
+      },
+      {
+        "name": "OnePlus Nord Newton"
+      },
+      {
+        "name": "OnePlus Nord Newton",
+        "id": "065814"
+      }
+    ],
+    "function": {
+      "dolbyAtmos": 1,
+      "customDress": 1,
+      "collectLogs": 1,
+      "firmwareCheckCommandId": 0,
+      "pairingModeTip": 5,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0,
+          "defaultFunction": 262144
+        }
+      ],
+      "holdInBoxPairing": 1,
+      "batteryInfo": 1,
+      "openBoxPairing": 1,
+      "related": 1,
+      "firmwareTrack": 1,
+      "equalizer": 4,
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "spatialDescriptionType": 4,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154529,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "gameSoundMutexes": [
+        1
+      ],
+      "promptVolume": 1,
+      "fastDiscovery": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "aiTranslate": 1
+    },
+    "name": "OnePlus Nord Buds 3r",
+    "id": "065854",
+    "type": "T2",
+    "supportSpp": true,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 52,
+      "firstRssi": 49,
+      "flattenOffset": 2
+    },
+    "minVersion": 15006000,
+    "function": {
+      "wearingVideoTutorial": 1,
+      "meetingAssistant": 1,
+      "customDress": 1,
+      "pairingModeTip": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 30,
+          "support": 131584,
+          "showEar": 0
+        }
+      ],
+      "related": 1,
+      "equalizer": 4,
+      "aiSummary": 1,
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1,
+      "tapLevelSetting": 1,
+      "minOtaBattery": 30,
+      "multiConnectFunctions": [
+        {
+          "minFirmVersion": 20,
+          "functionType": "displayPairedDevice"
+        },
+        {
+          "minFirmVersion": 20,
+          "functionType": "connectDisconnectDevice"
+        },
+        {
+          "minFirmVersion": 20,
+          "functionType": "unpairDevice"
+        }
+      ],
+      "functionIntroductionGuide": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154555,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "promptVolume": 1,
+      "longPressVolume": 1,
+      "equalizerModeByVersion": [
+        {
+          "modeType": 12,
+          "summaryId": 9,
+          "minAppVersion": 15007000,
+          "protocolIndex": 3,
+          "order": 4
+        }
+      ],
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "aiClearCall": 1,
+      "fastDiscovery": 1,
+      "controlAutoVolumeSupport": 1,
+      "voiceWake": 3,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 35,
+          "summaryId": 6,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 34,
+          "summaryId": 7,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 28,
+          "summaryId": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "tutorialGuide": 1,
+      "heyFindDevice": 1,
+      "aiTranslate": 1,
+      "introductionGuideList": [
+        2,
+        1,
+        4,
+        6,
+        7,
+        9,
+        5
+      ]
+    },
+    "name": "OPPO Enco Clip",
+    "id": "06B810",
+    "type": "O1",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 52,
+      "firstRssi": 49,
+      "flattenOffset": 2
+    },
+    "minVersion": 15006000,
+    "function": {
+      "wearingVideoTutorial": 1,
+      "meetingAssistant": 1,
+      "customDress": 1,
+      "pairingModeTip": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 30,
+          "support": 131584,
+          "showEar": 0
+        }
+      ],
+      "related": 1,
+      "equalizer": 4,
+      "aiSummary": 1,
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1,
+      "tapLevelSetting": 1,
+      "minOtaBattery": 30,
+      "multiConnectFunctions": [
+        {
+          "minFirmVersion": 20,
+          "functionType": "displayPairedDevice"
+        },
+        {
+          "minFirmVersion": 20,
+          "functionType": "connectDisconnectDevice"
+        },
+        {
+          "minFirmVersion": 20,
+          "functionType": "unpairDevice"
+        }
+      ],
+      "functionIntroductionGuide": 1,
+      "spatialDescriptionType": 4,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154553,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "promptVolume": 1,
+      "longPressVolume": 1,
+      "equalizerModeByVersion": [
+        {
+          "modeType": 12,
+          "summaryId": 9,
+          "minAppVersion": 15007000,
+          "protocolIndex": 3,
+          "order": 4
+        }
+      ],
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "aiClearCall": 1,
+      "fastDiscovery": 1,
+      "controlAutoVolumeSupport": 1,
+      "voiceWake": 3,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 35,
+          "summaryId": 6,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 34,
+          "summaryId": 7,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 28,
+          "summaryId": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "tutorialGuide": 1,
+      "heyFindDevice": 1,
+      "aiTranslate": 1,
+      "introductionGuideList": [
+        2,
+        1,
+        4,
+        6,
+        7,
+        9,
+        5
+      ]
+    },
+    "name": "OnePlus Open Buds",
+    "id": "065C14",
+    "type": "O1",
+    "supportSpp": true,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 51,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fitDetection": 1,
+      "clickTakePicNew": 1,
+      "highToneQuality": 1,
+      "hearingEnhancementNew": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 4,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        }
+      ],
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 612,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 515,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "support": 128,
+          "showEar": 1
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 4608,
+          "showEar": 1
+        }
+      ],
+      "batteryInfo": 1,
+      "wearDetection": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 1,
+      "equalizerMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 6,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 7,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1
+    },
+    "name": "OPPO Enco X",
+    "id": "061410",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "defaultColor": 0,
+    "minVersion": 4001000,
+    "function": {
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 7,
+          "showEar": 0
+        },
+        {
+          "action": 7
+        },
+        {
+          "action": 8
+        }
+      ],
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco Free",
+    "id": "060410",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 58,
+      "firstRssi": 53,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fitDetection": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 6,
+          "decideByEarDevice": true,
+          "protocolIndex": 3
+        }
+      ],
+      "personalNoise": 1,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 612,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8707,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 1
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "wearDetection": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 1,
+      "multiDevicesConnect": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 4,
+          "protocolIndex": 3
+        }
+      ],
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Free2",
+    "id": "062010",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 2,
+      "secondRssi": 53,
+      "firstRssi": 48,
+      "flattenOffset": 3
+    },
+    "minVersion": 4001000,
+    "function": {
+      "vocalEnhance": 1,
+      "functionGuide": 1,
+      "clickTakePicNew": 1,
+      "fastDiscovery": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "inBoxStatus": 0,
+      "findDevice": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 615,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8705,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "action": 13
+        }
+      ],
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco Play",
+    "id": "061C10",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 53,
+      "firstRssi": 48,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001000,
+    "function": {
+      "functionGuide": 1,
+      "clickTakePicNew": 1,
+      "fastDiscovery": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "inBoxStatus": 0,
+      "findDevice": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 615,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8705,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "action": 13
+        }
+      ],
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco Air",
+    "id": "061810",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001000,
+    "function": {
+      "openBoxPairing": 0,
+      "functionGuide": 1,
+      "dolbyAtmos": 1,
+      "fastDiscovery": 1,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 612,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8705,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "action": 12
+        }
+      ],
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco Buds",
+    "id": "062410",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001000,
+    "function": {
+      "openBoxPairing": 0,
+      "functionGuide": 1,
+      "dolbyAtmos": 1,
+      "fastDiscovery": 1,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 612,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8705,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "action": 12
+        }
+      ],
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco Air Lite",
+    "id": "062810",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 45,
+      "firstRssi": 45,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "wearDetection": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 743,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 513,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco W51",
+    "id": "060C10",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 63,
+      "firstRssi": 63,
+      "flattenOffset": 0
+    },
+    "defaultColor": 0,
+    "minVersion": 4001000,
+    "function": {
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco W31",
+    "id": "060810",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "defaultColor": 1,
+    "minVersion": 4001000,
+    "function": {
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "dolbyAtmos": 1,
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco W11",
+    "id": "061010",
+    "type": "T2",
+    "supportSpp": false,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "defaultColor": 1,
+    "minVersion": 4001101,
+    "function": {
+      "batteryInfo": 1
+    },
+    "name": "OPPO O-Free",
+    "id": "060412",
+    "type": "N",
+    "supportSpp": false,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "defaultColor": 1,
+    "minVersion": 4001000,
+    "function": {
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "dolbyAtmos": 1,
+      "inBoxStatus": 0,
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco W31 Lite",
+    "id": "062C10",
+    "type": "T2",
+    "supportSpp": false,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "defaultColor": 0,
+    "minVersion": 4001000,
+    "function": {
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco M31",
+    "id": "050410",
+    "type": "N",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "defaultColor": 0,
+    "minVersion": 4001000,
+    "function": {
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "dolbyAtmos": 1,
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco Quiet",
+    "id": "050010",
+    "type": "N",
+    "supportSpp": false,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "functionGuide": 0,
+      "fastDiscovery": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "inBoxStatus": 0,
+      "customDress": 1,
+      "findDevice": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 101,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1
+    },
+    "name": "OnePlus Buds",
+    "id": "060414",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "functionGuide": 0,
+      "fastDiscovery": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 101,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1
+    },
+    "name": "OnePlus Buds Z",
+    "id": "060814",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Buds Air",
+    "id": "3D59CF",
+    "protocolType": 2,
+    "type": "T1",
+    "podsVersion": 3007200,
+    "brand": "realme"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Buds Air Neo",
+    "id": "F85450",
+    "protocolType": 2,
+    "type": "T1",
+    "podsVersion": 3007200,
+    "brand": "realme"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 60,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Buds Wireless Pro",
+    "id": "E3009F",
+    "protocolType": 2,
+    "type": "N",
+    "podsVersion": 3007200,
+    "brand": "realme"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 60,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Buds Air Pro",
+    "id": "8CD10F",
+    "protocolType": 2,
+    "type": "T1",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "00001101-0000-1000-8000-00805F9B34FB"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Buds Air 2",
+    "id": "BA5D56",
+    "protocolType": 2,
+    "type": "T1",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "00001101-0000-1000-8000-00805F9B34FB"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Buds Air 2 Neo",
+    "id": "1B5374",
+    "protocolType": 2,
+    "type": "T1",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "00001101-0000-1000-8000-00805F9B34FB"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 60,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Buds Wireless 2",
+    "id": "C1E2B1",
+    "protocolType": 2,
+    "type": "N",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "00001101-0000-1000-8000-00805F9B34FB"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 60,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Buds Wireless 2 Neo",
+    "id": "C70A6D",
+    "protocolType": 2,
+    "type": "N",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Buds Q2",
+    "id": "693878",
+    "protocolType": 2,
+    "type": "T1",
+    "podsVersion": 3007200,
+    "brand": "realme"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Cobble Speaker",
+    "id": "49074B",
+    "protocolType": 2,
+    "type": "S",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 60,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Pocket Speaker",
+    "id": "C70A75",
+    "protocolType": 2,
+    "type": "S",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Brick Speaker",
+    "id": "A5FD66",
+    "protocolType": 2,
+    "type": "S",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 61,
+      "firstRssi": 56,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1,
+      "customDress": 1
+    },
+    "name": "realme Buds Air 3",
+    "id": "060812",
+    "protocolType": 1,
+    "type": "T1",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Buds Q2s",
+    "id": "060C12",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 60,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "realme Buds Wireless 2S",
+    "id": "050412",
+    "protocolType": 1,
+    "type": "N",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1,
+      "customDress": 1
+    },
+    "name": "realme Buds Air 3 Neo",
+    "id": "061812",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1,
+      "customDress": 1
+    },
+    "name": "realme Buds T100",
+    "id": "061412",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001270,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds Air 3S",
+    "supportRlmDeviceFunction": true,
+    "id": "061012",
+    "protocolType": 1,
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007270,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 55,
+      "flattenOffset": 0
+    },
+    "minVersion": 4007000,
+    "function": {
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds Air 5 Pro",
+    "supportRlmDeviceFunction": true,
+    "id": "061C12",
+    "protocolType": 1,
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 4007000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 55,
+      "flattenOffset": 0
+    },
+    "minVersion": 14004000,
+    "function": {
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds Air6 Pro",
+    "supportRlmDeviceFunction": true,
+    "id": "063012",
+    "protocolType": 1,
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 14004000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 60,
+      "flattenOffset": 0
+    },
+    "minVersion": 4007000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds Wireless 3",
+    "supportRlmDeviceFunction": true,
+    "id": "050812",
+    "protocolType": 1,
+    "type": "N",
+    "supportSpp": true,
+    "podsVersion": 4007000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4009000,
+    "function": {
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds Air 5",
+    "supportRlmDeviceFunction": true,
+    "id": "062012",
+    "protocolType": 1,
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 4009000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 14004000,
+    "function": {
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds Air6",
+    "supportRlmDeviceFunction": true,
+    "id": "063412",
+    "protocolType": 1,
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 14004000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 14004000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds N1 Pro",
+    "supportRlmDeviceFunction": true,
+    "id": "063812",
+    "protocolType": 1,
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 14004000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 14005000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds T310",
+    "supportRlmDeviceFunction": true,
+    "id": "063C12",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 14005000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 14005000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds N1",
+    "supportRlmDeviceFunction": true,
+    "id": "064012",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 14005000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4010000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds T300",
+    "supportRlmDeviceFunction": true,
+    "id": "062412",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 4010000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 15001000,
+    "function": {
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds Air7",
+    "supportRlmDeviceFunction": true,
+    "id": "064812",
+    "protocolType": 1,
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 15001000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 15003000,
+    "function": {
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds Air7 Pro",
+    "supportRlmDeviceFunction": true,
+    "id": "064C12",
+    "protocolType": 1,
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 15003000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 16003000,
+    "function": {
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds Air8 Pro",
+    "supportRlmDeviceFunction": true,
+    "id": "066C12",
+    "protocolType": 1,
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 16003000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 16002000,
+    "function": {
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds T500 Pro",
+    "supportRlmDeviceFunction": true,
+    "id": "066452",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 16002000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 16007000,
+    "function": {
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds T500 Pro Harry Potter Edition",
+    "supportRlmDeviceFunction": true,
+    "id": "067452",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 16007000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 16006000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds T500",
+    "supportRlmDeviceFunction": true,
+    "id": "067052",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 16006000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 15011000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1
+    },
+    "name": "realme Buds Clip",
+    "supportRlmDeviceFunction": true,
+    "id": "065C12",
+    "protocolType": 1,
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 15011000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 15005000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "realme Buds T200",
+    "supportRlmDeviceFunction": true,
+    "id": "065452",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 15005000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 14003000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "customDress": 1
+    },
+    "name": "realme Buds T110",
+    "id": "062812",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 14003000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 14006000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "customDress": 1
+    },
+    "name": "realme Buds T01",
+    "id": "064412",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 14006000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 15003000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1
+    },
+    "name": "realme Buds T200 Lite",
+    "id": "065052",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 15003000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 15006000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1
+    },
+    "name": "realme Buds T200x",
+    "id": "065852",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 15006000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 16001000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "inBoxStatus": 1,
+      "customDress": 1,
+      "findDevice": 1
+    },
+    "name": "realme TechLife Buds",
+    "supportRlmDeviceFunction": true,
+    "id": "066012",
+    "protocolType": 1,
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 16001000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 60,
+      "flattenOffset": 0
+    },
+    "minVersion": 14005000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1
+    },
+    "name": "realme Buds Wireless 3 Neo",
+    "supportRlmDeviceFunction": true,
+    "id": "050C12",
+    "protocolType": 1,
+    "type": "N",
+    "supportSpp": true,
+    "podsVersion": 14005000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 60,
+      "flattenOffset": 0
+    },
+    "minVersion": 15001000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1
+    },
+    "name": "realme Buds Wireless 5 ANC",
+    "supportRlmDeviceFunction": true,
+    "id": "051412",
+    "protocolType": 1,
+    "type": "N",
+    "supportSpp": true,
+    "podsVersion": 15001000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 60,
+      "flattenOffset": 0
+    },
+    "minVersion": 16007000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1
+    },
+    "name": "realme Buds Wireless 6 ANC",
+    "supportRlmDeviceFunction": true,
+    "id": "052052",
+    "protocolType": 1,
+    "type": "N",
+    "supportSpp": true,
+    "podsVersion": 16007000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 60,
+      "flattenOffset": 0
+    },
+    "minVersion": 16006000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "findDevice": 1
+    },
+    "name": "realme Buds Wireless 6 Neo",
+    "supportRlmDeviceFunction": true,
+    "id": "051812",
+    "protocolType": 1,
+    "type": "N",
+    "supportSpp": true,
+    "podsVersion": 16006000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 60,
+      "firstRssi": 60,
+      "flattenOffset": 0
+    },
+    "minVersion": 16007000,
+    "function": {
+      "fastDiscovery": 1,
+      "rlmMoreFunction": 1,
+      "findDevice": 1
+    },
+    "name": "realme Buds Wireless 6",
+    "supportRlmDeviceFunction": true,
+    "id": "051C52",
+    "protocolType": 1,
+    "type": "N",
+    "supportSpp": true,
+    "podsVersion": 16007000,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "DIZO Wireless",
+    "id": "C70A6E",
+    "protocolType": 2,
+    "type": "N",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "DIZO GoPods D",
+    "id": "C70A6F",
+    "protocolType": 2,
+    "type": "T1",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fastDiscovery": 1
+    },
+    "name": "DIZO GoPods",
+    "id": "C70A70",
+    "protocolType": 2,
+    "type": "T1",
+    "podsVersion": 3007200,
+    "brand": "realme",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001000,
+    "function": {
+      "fitDetection": 1,
+      "zenMode": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 7,
+          "protocolIndex": 4
+        },
+        {
+          "modeType": 4,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        }
+      ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 33,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "support": 128,
+          "showEar": 1
+        },
+        {
+          "ear": 2,
+          "action": 14,
+          "showEar": 1
+        },
+        {
+          "ear": 2,
+          "action": 15,
+          "showEar": 1
+        }
+      ],
+      "batteryInfo": 1,
+      "wearDetection": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "opsReduction": 1,
+      "multiDevicesConnect": 1,
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 13,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "customEqualizer": 1
+    },
+    "name": "OnePlus Buds Pro",
+    "id": "060C14",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 47,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 4001300,
+    "minVersion": 4001300,
+    "function": {
+      "spineHealth": 1,
+      "fitDetection": 1,
+      "headSetSoundRecord": 0,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "personalNoise": 1,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 32,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 33,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "functionGuide": 0,
+      "related": 1,
+      "equalizer": 4,
+      "multiDevicesConnect": 1,
+      "customEqualizer": 1,
+      "firmwareDiscovery": 1,
+      "clickTakePic": 1,
+      "zenMode": 1,
+      "spatialDescriptionType": 1,
+      "autoFirmwareUpdate": 1,
+      "equalizerModeCompat": [
+        {
+          "modeType": 19,
+          "minFirmVersion": 165,
+          "protocolIndex": 7
+        }
+      ],
+      "control": [
+        {
+          "ear": 2,
+          "action": 16,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 17,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 18,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 20,
+          "showEar": 1
+        }
+      ],
+      "spatialVip": 1,
+      "wearDetection": 1,
+      "supportPinch": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "controlAutoVolumeSupport": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1,
+        2
+      ],
+      "leFilterFunctions": [
+        {
+          "minVersion": 999,
+          "functionType": "highAudio"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "hiQualityAudio"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "goldHearing"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "spatialAudio"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "zenMode"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "personalTone"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "soundRecord"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "voiceWake"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "multiConnect"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "fitDetection"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "firmwareUpdate"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "collectLogs"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "diagnostic"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "channelSwitch"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "gameMode"
+        }
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "tag": 3,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 13,
+          "tag": 3,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 14,
+          "tag": 3,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "tag": 3,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "showTurnAutoSwitchOnDialog": true,
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus Buds Pro 2",
+    "id": "062014",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007300,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 47,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 4005000,
+    "minVersion": 4005000,
+    "function": {
+      "spineHealth": 0,
+      "fitDetection": 1,
+      "headSetSoundRecord": 0,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "personalNoise": 1,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 32,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 33,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "functionGuide": 0,
+      "related": 1,
+      "equalizer": 4,
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "firmwareDiscovery": 1,
+      "clickTakePic": 1,
+      "zenMode": 1,
+      "autoFirmwareUpdate": 1,
+      "equalizerModeCompat": [
+        {
+          "modeType": 19,
+          "minFirmVersion": 165,
+          "protocolIndex": 7
+        }
+      ],
+      "control": [
+        {
+          "ear": 2,
+          "action": 16,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 17,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 18,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 20,
+          "showEar": 1
+        }
+      ],
+      "wearDetection": 1,
+      "supportPinch": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "controlAutoVolumeSupport": 1,
+      "controlGuideSupport": 1,
+      "leFilterFunctions": [
+        {
+          "minVersion": 999,
+          "functionType": "highAudio"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "hiQualityAudio"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "goldHearing"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "spatialAudio"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "zenMode"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "personalTone"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "soundRecord"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "voiceWake"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "multiConnect"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "fitDetection"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "firmwareUpdate"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "collectLogs"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "diagnostic"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "channelSwitch"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "gameMode"
+        }
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "tag": 3,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 13,
+          "tag": 3,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 14,
+          "tag": 3,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "tag": 3,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "showTurnAutoSwitchOnDialog": true,
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus Buds Pro 2（轻享版）",
+    "id": "063014",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 4005000,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 47,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 4005000,
+    "minVersion": 4005000,
+    "function": {
+      "spineHealth": 0,
+      "fitDetection": 1,
+      "headSetSoundRecord": 0,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "personalNoise": 1,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 32,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 33,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "functionGuide": 0,
+      "related": 1,
+      "equalizer": 4,
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "firmwareDiscovery": 1,
+      "clickTakePic": 1,
+      "zenMode": 1,
+      "autoFirmwareUpdate": 1,
+      "equalizerModeCompat": [
+        {
+          "modeType": 19,
+          "minFirmVersion": 165,
+          "protocolIndex": 7
+        }
+      ],
+      "control": [
+        {
+          "ear": 2,
+          "action": 16,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 17,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 18,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 20,
+          "showEar": 1
+        }
+      ],
+      "wearDetection": 1,
+      "supportPinch": 1,
+      "fastDiscovery": 1,
+      "controlAutoVolumeSupport": 1,
+      "controlGuideSupport": 1,
+      "leFilterFunctions": [
+        {
+          "minVersion": 999,
+          "functionType": "highAudio"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "hiQualityAudio"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "goldHearing"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "spatialAudio"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "zenMode"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "personalTone"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "soundRecord"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "voiceWake"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "multiConnect"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "fitDetection"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "firmwareUpdate"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "collectLogs"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "diagnostic"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "channelSwitch"
+        },
+        {
+          "minVersion": 999,
+          "functionType": "gameMode"
+        }
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "tag": 3,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 13,
+          "tag": 3,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 14,
+          "tag": 3,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "tag": 3,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus Buds Pro 2R",
+    "id": "063414",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 4005000,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 48,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 4003000,
+    "minVersion": 4003000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "multiDevicesConnect": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Air3",
+    "id": "064C10",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 4003000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 52,
+      "firstRssi": 49,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 4005000,
+    "minVersion": 4005000,
+    "function": {
+      "fitDetection": 1,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 1
+        }
+      ],
+      "batteryInfo": 1,
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "multiDevicesConnect": 1,
+      "personalNoiseCompat": {
+        "personalNoise": 1,
+        "minFirmVersion": 150
+      },
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "highAudio": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 20,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Air3 Pro",
+    "id": "065C10",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 4005000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 48,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 4007000,
+    "minVersion": 4007000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "multiDevicesConnect": 1,
+      "equalizerMode": [
+        {
+          "modeType": 21,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco R2",
+    "id": "065810",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 4007000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 52,
+      "firstRssi": 49,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 4005000,
+    "minVersion": 4005000,
+    "function": {
+      "fitDetection": 1,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "batteryInfo": 1,
+      "related": 1,
+      "equalizer": 2,
+      "multiDevicesConnect": 1,
+      "personalNoiseCompat": {
+        "personalNoise": 1,
+        "minFirmVersion": 150
+      },
+      "highAudio": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 1
+        }
+      ],
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 20,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1
+    },
+    "name": "OPPO Enco Free3",
+    "id": "066010",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 4005000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 54,
+      "firstRssi": 51,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001006,
+    "function": {
+      "fitDetection": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 4,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        }
+      ],
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 612,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 613,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 613,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "support": 128,
+          "showEar": 1
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 4608,
+          "showEar": 1
+        }
+      ],
+      "batteryInfo": 1,
+      "wearDetection": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 13,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "customEqualizer": 1
+    },
+    "name": "OnePlus Buds Z2",
+    "id": "061014",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "defaultColor": 0,
+    "minVersion": 4001000,
+    "function": {
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "dolbyAtmos": 1,
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco M32",
+    "id": "050810",
+    "type": "N",
+    "supportSpp": false,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 53,
+      "firstRssi": 48,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001242,
+    "function": {
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 1,
+      "controlGuideSupport": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 4,
+          "protocolIndex": 3
+        }
+      ],
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco R",
+    "id": "063010",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007242,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 53,
+      "firstRssi": 48,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001100,
+    "function": {
+      "dolbyAtmos": 1,
+      "controlList": [
+        {
+          "control": [
+            {
+              "ear": 2,
+              "action": 1,
+              "support": 516,
+              "showEar": 0
+            },
+            {
+              "ear": 2,
+              "action": 2,
+              "support": 8807,
+              "showEar": 0
+            },
+            {
+              "ear": 2,
+              "action": 3,
+              "support": 8803,
+              "showEar": 0
+            },
+            {
+              "ear": 2,
+              "action": 4,
+              "support": 536,
+              "showEar": 0
+            }
+          ],
+          "version": 120
+        }
+      ],
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 612,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8707,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 1,
+      "controlGuideSupport": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Air2",
+    "id": "063410",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 53,
+      "firstRssi": 48,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001250,
+    "function": {
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "dolbyAtmos": 1,
+      "equalizer": 4,
+      "autoFirmwareUpdate": 1,
+      "controlGuideSupport": 1,
+      "equalizerMode": [
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 17,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 15,
+          "protocolIndex": 3
+        }
+      ],
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        }
+      ],
+      "diagnostic": 1,
+      "clickTakePic": 1,
+      "batteryInfo": 1
+    },
+    "name": "OnePlus Nord Buds CE",
+    "id": "061C14",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007250,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 58,
+      "firstRssi": 53,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001100,
+    "function": {
+      "fitDetection": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 6,
+          "decideByEarDevice": true,
+          "protocolIndex": 3
+        }
+      ],
+      "personalNoise": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 612,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8707,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 1
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "wearDetection": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 1,
+      "multiDevicesConnect": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 4,
+          "protocolIndex": 3
+        }
+      ],
+      "findDevice": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Free2i",
+    "id": "064010",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001011,
+    "function": {
+      "functionGuide": 0,
+      "fastDiscovery": 0,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "inBoxStatus": 0,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 101,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1
+    },
+    "name": "OnePlus Buds",
+    "id": "068414",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 53,
+      "firstRssi": 50,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001200,
+    "function": {
+      "fitDetection": 1,
+      "longPowerMode": 0,
+      "headSetSoundRecord": 1,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            },
+            {
+              "modeType": 6,
+              "protocolIndex": 9
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "personalNoise": 1,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 32,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 33,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "functionGuide": 0,
+      "related": 1,
+      "equalizer": 1,
+      "multiDevicesConnect": 1,
+      "highAudio": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1,
+      "smartCall": 0,
+      "autoFirmwareUpdate": 1,
+      "equalizerModeCompat": [
+        {
+          "modeType": 16,
+          "minFirmVersion": 112,
+          "protocolIndex": 4,
+          "order": 1
+        }
+      ],
+      "deviceLostRemind": 0,
+      "control": [
+        {
+          "ear": 2,
+          "action": 16,
+          "support": 612,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 17,
+          "support": 615,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 18,
+          "support": 615,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 20,
+          "showEar": 1
+        }
+      ],
+      "voiceCommand": 1,
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "supportPinch": 1,
+      "fastDiscovery": 1,
+      "voiceWake": 1,
+      "controlGuideSupport": 1,
+      "equalizerMode": [
+        {
+          "modeType": 10,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 9,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 6,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 8,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "showTurnAutoSwitchOnDialog": true
+    },
+    "name": "OPPO Enco X2",
+    "id": "063C10",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007212,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001011,
+    "function": {
+      "functionGuide": 0,
+      "fastDiscovery": 0,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 101,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1
+    },
+    "name": "OnePlus Buds Z",
+    "id": "068814",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007200,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
       "secondRssi": 58,
       "firstRssi": 53,
       "flattenOffset": 2
@@ -541,60 +6488,1575 @@
     "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
   },
   {
-    "minVersion": 16003000,
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "defaultColor": 2,
+    "minVersion": 4001220,
     "function": {
+      "fastDiscovery": 1,
+      "batteryInfo": 1
+    },
+    "name": "OnePlus Bullets Wireless Z2",
+    "id": "050414",
+    "type": "N",
+    "supportSpp": false,
+    "podsVersion": 3007220,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001230,
+    "function": {
+      "dolbyAtmos": 1,
+      "controlList": [
+        {
+          "control": [
+            {
+              "ear": 2,
+              "action": 1,
+              "support": 516,
+              "showEar": 0
+            },
+            {
+              "ear": 2,
+              "action": 2,
+              "support": 8805,
+              "showEar": 0
+            },
+            {
+              "ear": 2,
+              "action": 3,
+              "support": 8801,
+              "showEar": 0
+            },
+            {
+              "ear": 2,
+              "action": 6,
+              "support": 4608,
+              "showEar": 1
+            }
+          ],
+          "version": 108
+        }
+      ],
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 613,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 609,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 4608,
+          "showEar": 1
+        }
+      ],
       "batteryInfo": 1,
-      "wearDetection": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 4,
+      "controlGuideSupport": 1,
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 13,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1
+    },
+    "name": "OnePlus Nord Buds",
+    "id": "061414",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007230,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 4001230,
+    "function": {
+      "dolbyAtmos": 1,
+      "controlList": [
+        {
+          "control": [
+            {
+              "ear": 2,
+              "action": 1,
+              "support": 516,
+              "showEar": 0
+            },
+            {
+              "ear": 2,
+              "action": 2,
+              "support": 8805,
+              "showEar": 0
+            },
+            {
+              "ear": 2,
+              "action": 3,
+              "support": 8801,
+              "showEar": 0
+            },
+            {
+              "ear": 2,
+              "action": 6,
+              "support": 4608,
+              "showEar": 1
+            }
+          ],
+          "version": 108
+        }
+      ],
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 613,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 609,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 4608,
+          "showEar": 1
+        }
+      ],
+      "batteryInfo": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 4,
+      "controlGuideSupport": 1,
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 13,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1
+    },
+    "name": "OnePlus Buds N",
+    "id": "061814",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 3007230,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 54,
+      "firstRssi": 52,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001250,
+    "function": {
       "fastDiscovery": 1,
       "related": 1,
       "equalizer": 2,
-      "multiDevicesConnect": 1,
-      "diagnostic": 1,
-      "findDevice": 1,
-      "clickTakePic": 1,
-      "autoFirmwareUpdate": 1,
+      "controlGuideSupport": 1,
       "customDress": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "clickTakePic": 1,
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco Air2i",
+    "id": "064410",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007250,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 54,
+      "firstRssi": 52,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001250,
+    "function": {
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "customDress": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "clickTakePic": 1,
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco Buds2",
+    "id": "064810",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007250,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 58,
+      "firstRssi": 53,
+      "flattenOffset": 2
+    },
+    "minVersion": 4001290,
+    "function": {
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 6,
+          "decideByEarDevice": true,
+          "protocolIndex": 3
+        }
+      ],
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 612,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8707,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 4632,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 1
+        }
+      ],
+      "batteryInfo": 1,
+      "wearDetection": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "equalizerMode": [
+        {
+          "modeType": 18,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco R Pro",
+    "id": "065010",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 3007290,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 53,
+      "firstRssi": 51,
+      "flattenOffset": 0
+    },
+    "minVersion": 4004000,
+    "function": {
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 2
+        }
+      ],
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 1
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 4608,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 4,
+      "controlGuideSupport": 1,
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 13,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "customEqMax": 2,
+      "clickTakePic": 1,
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus Nord Buds 2",
+    "id": "062414",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 4004000,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "opsPodsVersion": 4007000,
+    "minVersion": 4007000,
+    "function": {
+      "dolbyAtmos": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 4608,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "holdInBoxPairing": 1,
+      "batteryInfo": 1,
+      "openBoxPairing": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 4,
+      "controlGuideSupport": 1,
+      "inBoxStatus": 0,
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 13,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1
+    },
+    "name": "OnePlus Nord Buds 2r",
+    "id": "062C14",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 4007000,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 53,
+      "firstRssi": 51,
+      "flattenOffset": 0
+    },
+    "minVersion": 4004000,
+    "function": {
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 2
+        }
+      ],
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 1
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 4608,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 4,
+      "controlGuideSupport": 1,
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 13,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "gameEqualizer": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "customEqMax": 2,
+      "gameEqPkgList": [
+        "com.tencent.tmgp.pubgmhd"
+      ],
+      "clickTakePic": 1,
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus Buds Ace",
+    "id": "062814",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 4004000,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 53,
+      "firstRssi": 48,
+      "flattenOffset": 2
+    },
+    "minVersion": 4008000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "inBoxStatus": 0,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Air2（新声版）",
+    "id": "066C10",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 4008000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 53,
+      "firstRssi": 48,
+      "flattenOffset": 2
+    },
+    "minVersion": 4008000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "functionGuide": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "inBoxStatus": 0,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Air3i",
+    "id": "067010",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 4008000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 53,
+      "flattenOffset": 0
+    },
+    "minVersion": 4008000,
+    "function": {
+      "minOtaBattery": 50,
+      "fitDetection": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 2
+        }
+      ],
+      "control": [
+        {
+          "ear": 2,
+          "minSelectCount": 2,
+          "action": 25,
+          "showEar": 1
+        },
+        {
+          "ear": 2,
+          "action": 26,
+          "support": 4608,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 36,
+          "support": 524288,
+          "showEar": 1
+        },
+        {
+          "ear": 2,
+          "action": 37,
+          "support": 262144,
+          "showEar": 1
+        }
+      ],
+      "batteryInfo": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 13,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "gameEqualizer": 1,
+      "diagnostic": 1,
+      "gameEqPkgList": [
+        "com.tencent.tmgp.pubgmhd"
+      ],
+      "bassEngineSupport": 1
+    },
+    "name": "OPPO Enco M33",
+    "id": "050C10",
+    "type": "N",
+    "supportSpp": true,
+    "podsVersion": 4008000,
+    "brand": "oppo",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 53,
+      "flattenOffset": 0
+    },
+    "minVersion": 4008000,
+    "function": {
+      "minOtaBattery": 50,
+      "fitDetection": 1,
+      "dolbyAtmos": 1,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 2
+        }
+      ],
+      "control": [
+        {
+          "ear": 2,
+          "action": 25,
+          "showEar": 1
+        },
+        {
+          "ear": 2,
+          "action": 26,
+          "support": 4608,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 36,
+          "support": 524288,
+          "showEar": 1
+        },
+        {
+          "ear": 2,
+          "action": 37,
+          "support": 262144,
+          "showEar": 1
+        }
+      ],
+      "batteryInfo": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 4,
+      "controlGuideSupport": 1,
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 13,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "customEqMax": 3,
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus BulletsWireless Z2 ANC",
+    "id": "050C14",
+    "type": "N",
+    "supportSpp": true,
+    "podsVersion": 4008000,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 65,
+      "firstRssi": 65,
+      "flattenOffset": 0
+    },
+    "minVersion": 15003000,
+    "function": {
+      "minOtaBattery": 50,
+      "musicControl": [
+        {
+          "button": 2,
+          "ear": 2,
+          "action": 1,
+          "support": 8,
+          "showEar": 1
+        },
+        {
+          "button": 3,
+          "ear": 2,
+          "action": 1,
+          "support": 16,
+          "showEar": 1
+        },
+        {
+          "button": 2,
+          "ear": 2,
+          "action": 4,
+          "support": 8,
+          "showEar": 1
+        },
+        {
+          "button": 3,
+          "ear": 2,
+          "action": 4,
+          "support": 16,
+          "showEar": 1
+        }
+      ],
+      "spatialDescriptionType": 4,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "button": 5,
+          "ear": 2,
+          "action": 1,
+          "support": 4,
+          "showEar": 1
+        },
+        {
+          "button": 5,
+          "ear": 2,
+          "action": 2,
+          "support": 64,
+          "showEar": 1
+        },
+        {
+          "button": 5,
+          "ear": 2,
+          "action": 3,
+          "support": 32,
+          "showEar": 1
+        },
+        {
+          "button": 5,
+          "ear": 2,
+          "action": 4,
+          "support": 1,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "button": 5,
+          "ear": 2,
+          "action": 1,
+          "support": 524288,
+          "showEar": 1
+        },
+        {
+          "button": 5,
+          "ear": 2,
+          "action": 4,
+          "support": 262144,
+          "showEar": 1
+        }
+      ],
+      "batteryInfo": 1,
+      "fastDiscovery": 1,
+      "equalizer": 4,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 13,
+          "tag": 0,
+          "protocolIndex": 2
+        }
+      ],
+      "customEqMax": 3,
+      "diagnostic": 1,
+      "customEqualizer": 0,
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus Bullets Wireless Z3",
+    "id": "051014",
+    "type": "N",
+    "supportSpp": true,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 47,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 14001001,
+    "minVersion": 14001001,
+    "function": {
+      "fitDetection": 1,
+      "headSetSoundRecord": 0,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
       "noiseReductionMode": [
         {
           "modeType": 5,
           "childrenMode": [
-            { "modeType": 7, "protocolIndex": 7 },
-            { "modeType": 4, "protocolIndex": 4 },
-            { "modeType": 8, "protocolIndex": 5 },
-            { "modeType": 3, "protocolIndex": 6 }
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
           ],
           "protocolIndex": 1
         },
         {
           "modeType": 1,
           "childrenMode": [
-            { "modeType": 1, "protocolIndex": 3 }
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
           ],
           "protocolIndex": 0
         },
         {
           "modeType": 2,
           "childrenMode": [
-            { "modeType": 2, "protocolIndex": 8 }
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
           ],
           "protocolIndex": 2
         }
       ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "functionGuide": 0,
+      "related": 1,
+      "equalizer": 4,
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "cleanGuide": 1,
+      "spatialDescriptionType": 4,
+      "autoFirmwareUpdate": 1,
+      "equalizerModeCompat": [
+        {
+          "modeType": 13,
+          "minFirmVersion": 119,
+          "tag": 0,
+          "protocolIndex": 3,
+          "order": 4
+        }
+      ],
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "minSelectCount": 1,
+          "action": 27,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        }
+      ],
+      "gameSoundMutexes": [
+        1,
+        2,
+        3
+      ],
+      "spatialVip": 1,
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "controlAutoVolumeSupport": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
       "equalizerMode": [
-        { "modeType": 22, "protocolIndex": 0 },
-        { "modeType": 31, "protocolIndex": 1 },
-        { "modeType": 32, "protocolIndex": 2 }
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 1
+        }
       ],
+      "findDevice": 1,
+      "earScan": 1,
       "gameSoundList": [
-        { "type": 3 },
-        { "type": 0 }
+        {
+          "packageName": "com.tencent.tmgp.pubgmhd",
+          "type": 1
+        },
+        {
+          "type": 0
+        }
       ],
-      "gameSoundMutexes": [1]
+      "bassEngineSupport": 1
     },
-    "name": "OPPO Enco Air4 Pro",
-    "id": "06B810",
+    "name": "OnePlus Buds 3",
+    "id": "063C14",
     "type": "T1",
     "supportSpp": true,
+    "podsVersion": 14001001,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 47,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 14001001,
+    "minVersion": 14001001,
+    "function": {
+      "fitDetection": 1,
+      "headSetSoundRecord": 0,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "functionGuide": 0,
+      "related": 1,
+      "equalizer": 2,
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1,
+      "cleanGuide": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "equalizerModeCompat": [
+        {
+          "modeType": 13,
+          "minFirmVersion": 119,
+          "tag": 0,
+          "protocolIndex": 3,
+          "order": 4
+        }
+      ],
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 27,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        }
+      ],
+      "spatialVip": 1,
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "controlAutoVolumeSupport": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "bassEngineSupport": 1
+    },
+    "name": "OPPO Enco X3i",
+    "id": "066810",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 14001001,
     "brand": "oppo",
     "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
   },
@@ -839,6 +8301,1549 @@
     "rssi": {
       "rightOffset": 0,
       "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 47,
+      "flattenOffset": 2
+    },
+    "minVersion": 14008000,
+    "function": {
+      "spineHealth": 1,
+      "strongNoiseReductionRealTime": 1,
+      "fitDetection": 1,
+      "headSetSoundRecord": 1,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 32,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 33,
+          "support": 262656,
+          "showEar": 0,
+          "defaultFunction": 262144
+        },
+        {
+          "ear": 2,
+          "action": 34,
+          "support": 131584,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "functionGuide": 0,
+      "immersiveRecord": 0,
+      "related": 1,
+      "equalizer": 4,
+      "multiDevicesConnect": 1,
+      "hearingJudgeDb": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "cleanGuide": 1,
+      "zenMode": 2,
+      "spatialDescriptionType": 1,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 16,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 17,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 18,
+          "support": 3220067,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 20,
+          "showEar": 1
+        }
+      ],
+      "gameSoundMutexes": [
+        1
+      ],
+      "spatialHiResMutex": 1,
+      "spatialVip": 1,
+      "dialogTags": [
+        1
+      ],
+      "wearDetection": 1,
+      "supportPinch": 1,
+      "fastDiscovery": 1,
+      "controlAutoVolumeSupport": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1,
+        2
+      ],
+      "leFilterFunctions": [
+        {
+          "minFirmVersion": 25,
+          "minAppVersion": 14007000,
+          "functionType": "goldHearing",
+          "needConnectSpp": false
+        },
+        {
+          "minFirmVersion": 25,
+          "minAppVersion": 14007000,
+          "functionType": "personalTone",
+          "needConnectSpp": true
+        },
+        {
+          "minFirmVersion": 25,
+          "minAppVersion": 14007000,
+          "functionType": "fitDetection",
+          "needConnectSpp": false
+        },
+        {
+          "minFirmVersion": 25,
+          "minAppVersion": 14007000,
+          "functionType": "firmwareUpdate",
+          "needConnectSpp": true
+        },
+        {
+          "minFirmVersion": 25,
+          "minAppVersion": 14007000,
+          "functionType": "collectLogs",
+          "needConnectSpp": true
+        }
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "summaryId": 1,
+          "tag": 3,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 13,
+          "summaryId": 2,
+          "tag": 3,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 14,
+          "summaryId": 3,
+          "tag": 3,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 12,
+          "summaryId": 4,
+          "tag": 3,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 30,
+          "summaryId": 5,
+          "tag": 3,
+          "protocolIndex": 7
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "tutorialGuide": 1,
+      "aiTranslate": 1,
+      "gameSoundList": [
+        {
+          "type": 3
+        },
+        {
+          "type": 0
+        }
+      ],
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus Buds Pro 3",
+    "id": "064014",
+    "type": "T1",
+    "supportSpp": true,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 55,
+      "firstRssi": 48,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 14000000,
+    "minVersion": 14000000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "multiDevicesConnect": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Air3s",
+    "id": "067810",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 14000000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 14000000,
+    "function": {
+      "dolbyAtmos": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 4608,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "holdInBoxPairing": 1,
+      "batteryInfo": 1,
+      "openBoxPairing": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "inBoxStatus": 0,
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 13,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Buds2 Pro",
+    "id": "068010",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 14000000,
+    "brand": "oppo",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 14002000,
+    "function": {
+      "dolbyAtmos": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 4608,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "holdInBoxPairing": 1,
+      "batteryInfo": 1,
+      "openBoxPairing": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 4,
+      "controlGuideSupport": 1,
+      "inBoxStatus": 0,
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 13,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1
+    },
+    "name": "OnePlus Buds V",
+    "id": "064814",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 14002000,
+    "brand": "OnePlus",
+    "uuid": "00001107-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 54,
+      "firstRssi": 52,
+      "flattenOffset": 2
+    },
+    "minVersion": 14004000,
+    "function": {
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "customDress": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "clickTakePic": 1,
+      "batteryInfo": 1
+    },
+    "name": "OPPO Enco Air 3i",
+    "id": "068810",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 14004000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 53,
+      "firstRssi": 48,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 14005000,
+    "minVersion": 14005000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 4,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "inBoxStatus": 0,
+      "equalizerMode": [
+        {
+          "modeType": 25,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco R3",
+    "id": "068410",
+    "type": "T2",
+    "supportSpp": true,
+    "podsVersion": 14005000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 14004000,
+    "minVersion": 14004000,
+    "function": {
+      "fitDetection": 1,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "personalNoise": 1,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "related": 1,
+      "equalizer": 2,
+      "personalNoiseCompat": {
+        "personalNoise": 1,
+        "minFirmVersion": 150
+      },
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 1
+        }
+      ],
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1
+    },
+    "name": "OPPO Enco Air4 Pro",
+    "id": "067C10",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 14004000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 14004000,
+    "minVersion": 14004000,
+    "function": {
+      "fitDetection": 1,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "personalNoise": 1,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "related": 1,
+      "equalizer": 4,
+      "multiDevicesConnect": 1,
+      "personalNoiseCompat": {
+        "personalNoise": 1,
+        "minFirmVersion": 150
+      },
+      "customEqualizer": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1,
+      "spatialDescriptionType": 4,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 1
+        }
+      ],
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 4
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 5
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus Nord Buds 3 Pro",
+    "id": "064414",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 14004000,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 14008000,
+    "minVersion": 14008000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 2
+        }
+      ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "minSelectCount": 1,
+          "action": 11,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "multiDevicesConnect": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Air4",
+    "id": "069010",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 14008000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 14008000,
+    "minVersion": 14008000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 4,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 2
+        }
+      ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "minSelectCount": 1,
+          "action": 11,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 4,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "multiDevicesConnect": 1,
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 4
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 5
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus Nord Buds 3",
+    "id": "065014",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 14008000,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 15001000,
+    "minVersion": 15001000,
+    "function": {
+      "fitDetection": 1,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            },
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        }
+      ],
+      "personalNoise": 1,
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "related": 1,
+      "equalizer": 2,
+      "personalNoiseCompat": {
+        "personalNoise": 1,
+        "minFirmVersion": 150
+      },
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 11,
+          "showEar": 1
+        }
+      ],
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 33,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1
+    },
+    "name": "OPPO Enco R3 Pro",
+    "id": "069C10",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 15001000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 15001000,
+    "minVersion": 15001000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 2
+        }
+      ],
+      "hearingEnhancement": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "minSelectCount": 1,
+          "action": 11,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 2,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "multiDevicesConnect": 1,
+      "equalizerMode": [
+        {
+          "modeType": 1,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 3,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "diagnostic": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Buds3 Pro+",
+    "id": "06A010",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 15001000,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 57,
+      "firstRssi": 54,
+      "flattenOffset": 2
+    },
+    "opsPodsVersion": 15001000,
+    "minVersion": 15001000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 4,
+      "autoFirmwareUpdate": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 1,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 2,
+          "protocolIndex": 2
+        }
+      ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8803,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "minSelectCount": 1,
+          "action": 11,
+          "showEar": 1
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524288,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262144,
+          "showEar": 0
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 4,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "multiDevicesConnect": 1,
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 3
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 4
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 5
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus Buds Ace 2",
+    "id": "064C14",
+    "type": "T1",
+    "supportSpp": true,
+    "podsVersion": 15001000,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
       "secondRssi": 44,
       "firstRssi": 44,
       "flattenOffset": 2
@@ -1015,6 +10020,1088 @@
     "name": "OPPO Enco Free4",
     "id": "068C10",
     "type": "T1",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 44,
+      "firstRssi": 44,
+      "flattenOffset": 2
+    },
+    "minVersion": 15003002,
+    "function": {
+      "strongNoiseReductionRealTime": 1,
+      "noiseReductionUIVersion": 2,
+      "fitDetection": 1,
+      "headSetSoundRecord": 0,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            },
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 10,
+          "protocolIndex": 11
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        }
+      ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 30,
+          "support": 131584,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0,
+          "defaultFunction": 262144
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "functionGuide": 0,
+      "related": 1,
+      "equalizer": 4,
+      "aiSummary": 1,
+      "multiDevicesConnect": 1,
+      "hearingJudgeDb": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "cleanGuide": 1,
+      "spatialDescriptionType": 2,
+      "functionIntroductionGuide": 1,
+      "autoFirmwareUpdate": 1,
+      "equalizerModeCompat": [
+        {
+          "modeType": 34,
+          "minFirmVersion": 118,
+          "tag": 0,
+          "protocolIndex": 7,
+          "order": 4
+        }
+      ],
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154531,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "minSelectCount": 1,
+          "action": 27,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        }
+      ],
+      "spatialHiResMutex": 1,
+      "promptVolume": 1,
+      "spatialVip": 1,
+      "dialogTags": [
+        2
+      ],
+      "equalizerModeByVersion": [
+        {
+          "modeType": 40,
+          "minFirmVersion": 136,
+          "minAppVersion": 15011000,
+          "tag": 3,
+          "protocolIndex": 8,
+          "order": 6
+        }
+      ],
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "controlAutoVolumeSupport": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 26,
+          "protocolIndex": 0,
+          "order": 1
+        },
+        {
+          "modeType": 28,
+          "protocolIndex": 1,
+          "order": 2
+        },
+        {
+          "modeType": 29,
+          "protocolIndex": 2,
+          "order": 3
+        },
+        {
+          "modeType": 30,
+          "tag": 3,
+          "protocolIndex": 3,
+          "order": 5
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "aiTranslate": 1
+    },
+    "name": "OPPO Enco Free4（丹拿版）",
+    "id": "06C010",
+    "type": "T1",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 44,
+      "firstRssi": 44,
+      "flattenOffset": 2
+    },
+    "minVersion": 15003002,
+    "function": {
+      "strongNoiseReductionRealTime": 1,
+      "noiseReductionUIVersion": 2,
+      "fitDetection": 1,
+      "headSetSoundRecord": 0,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            },
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 10,
+          "protocolIndex": 11
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        }
+      ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 30,
+          "support": 131584,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0,
+          "defaultFunction": 262144
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "functionGuide": 0,
+      "related": 1,
+      "equalizer": 4,
+      "aiSummary": 1,
+      "multiDevicesConnect": 1,
+      "hearingJudgeDb": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "cleanGuide": 1,
+      "spatialDescriptionType": 2,
+      "functionIntroductionGuide": 1,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154531,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "minSelectCount": 1,
+          "action": 27,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        }
+      ],
+      "spatialHiResMutex": 1,
+      "promptVolume": 1,
+      "spatialVip": 1,
+      "dialogTags": [
+        2
+      ],
+      "equalizerModeByVersion": [
+        {
+          "modeType": 40,
+          "minFirmVersion": 136,
+          "minAppVersion": 15011000,
+          "tag": 3,
+          "protocolIndex": 8,
+          "order": 5
+        }
+      ],
+      "wearDetection": 1,
+      "fastDiscovery": 1,
+      "controlAutoVolumeSupport": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 26,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 28,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 29,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 30,
+          "tag": 3,
+          "protocolIndex": 3
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "aiTranslate": 1
+    },
+    "name": "OPPO Enco X3s",
+    "id": "06BC10",
+    "type": "T1",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 44,
+      "firstRssi": 44,
+      "flattenOffset": 2
+    },
+    "minVersion": 15003002,
+    "function": {
+      "strongNoiseReductionRealTime": 1,
+      "noiseReductionUIVersion": 2,
+      "fitDetection": 1,
+      "headSetSoundRecord": 0,
+      "highToneQuality": 1,
+      "dolbyAtmos": 1,
+      "noiseReductionMode": [
+        {
+          "modeType": 5,
+          "childrenMode": [
+            {
+              "modeType": 4,
+              "protocolIndex": 4
+            },
+            {
+              "modeType": 8,
+              "protocolIndex": 5
+            },
+            {
+              "modeType": 3,
+              "protocolIndex": 6
+            },
+            {
+              "modeType": 7,
+              "protocolIndex": 7
+            }
+          ],
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 10,
+          "protocolIndex": 11
+        },
+        {
+          "modeType": 2,
+          "childrenMode": [
+            {
+              "modeType": 2,
+              "protocolIndex": 8
+            }
+          ],
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 1,
+          "childrenMode": [
+            {
+              "modeType": 1,
+              "protocolIndex": 3
+            }
+          ],
+          "protocolIndex": 0
+        }
+      ],
+      "customDress": 1,
+      "hearingEnhancement": 1,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 30,
+          "support": 131584,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0,
+          "defaultFunction": 262144
+        }
+      ],
+      "batteryInfo": 1,
+      "feedback": 1,
+      "functionGuide": 0,
+      "related": 1,
+      "equalizer": 4,
+      "aiSummary": 1,
+      "multiDevicesConnect": 1,
+      "hearingJudgeDb": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "cleanGuide": 1,
+      "spatialDescriptionType": 4,
+      "functionIntroductionGuide": 1,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8807,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154531,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "minSelectCount": 1,
+          "action": 27,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 5,
+          "support": 3584,
+          "showEar": 0
+        }
+      ],
+      "spatialHiResMutex": 1,
+      "promptVolume": 1,
+      "spatialVip": 1,
+      "dialogTags": [
+        2
+      ],
+      "wearDetection": 1,
+      "autoSwitchLink": 1,
+      "fastDiscovery": 1,
+      "controlAutoVolumeSupport": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 11,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 14,
+          "protocolIndex": 1
+        },
+        {
+          "modeType": 12,
+          "protocolIndex": 2
+        }
+      ],
+      "findDevice": 1,
+      "earScan": 1,
+      "aiTranslate": 1,
+      "bassEngineSupport": 1
+    },
+    "name": "OnePlus Buds 4",
+    "id": "065414",
+    "type": "T1",
+    "supportSpp": true,
+    "brand": "OnePlus",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 59,
+      "firstRssi": 56,
+      "flattenOffset": 0
+    },
+    "minVersion": 15003002,
+    "function": {
+      "dolbyAtmos": 1,
+      "customDress": 1,
+      "firmwareCheckCommandId": 0,
+      "pairingModeTip": 5,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0,
+          "defaultFunction": 262144
+        }
+      ],
+      "holdInBoxPairing": 1,
+      "batteryInfo": 1,
+      "openBoxPairing": 1,
+      "related": 1,
+      "equalizer": 4,
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "gameSoundMutexes": [
+        1
+      ],
+      "promptVolume": 1,
+      "fastDiscovery": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 22,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 31,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 32,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "gameSoundList": [
+        {
+          "type": 3
+        },
+        {
+          "type": 0
+        }
+      ]
+    },
+    "name": "OPPO Enco Buds3 Pro",
+    "id": "06A850",
+    "type": "T2",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 59,
+      "firstRssi": 56,
+      "flattenOffset": 0
+    },
+    "minVersion": 15003002,
+    "function": {
+      "dolbyAtmos": 1,
+      "customDress": 1,
+      "firmwareCheckCommandId": 0,
+      "pairingModeTip": 5,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0,
+          "defaultFunction": 262144
+        }
+      ],
+      "holdInBoxPairing": 1,
+      "batteryInfo": 1,
+      "openBoxPairing": 1,
+      "related": 1,
+      "equalizer": 4,
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "gameSoundMutexes": [
+        1
+      ],
+      "promptVolume": 1,
+      "fastDiscovery": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 22,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 31,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 32,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "gameSoundList": [
+        {
+          "type": 3
+        },
+        {
+          "type": 0
+        }
+      ]
+    },
+    "name": "OPPO Enco Air4i",
+    "id": "069850",
+    "type": "T2",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 59,
+      "firstRssi": 56,
+      "flattenOffset": 0
+    },
+    "minVersion": 15003002,
+    "function": {
+      "dolbyAtmos": 1,
+      "customDress": 1,
+      "firmwareCheckCommandId": 0,
+      "pairingModeTip": 5,
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0,
+          "defaultFunction": 262144
+        }
+      ],
+      "holdInBoxPairing": 1,
+      "batteryInfo": 1,
+      "openBoxPairing": 1,
+      "related": 1,
+      "equalizer": 4,
+      "multiDevicesConnect": 1,
+      "diagnostic": 1,
+      "customEqualizer": 1,
+      "clickTakePic": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 8801,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "gameSoundMutexes": [
+        1
+      ],
+      "promptVolume": 1,
+      "fastDiscovery": 1,
+      "controlGuideSupport": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 22,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 31,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 32,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "gameSoundList": [
+        {
+          "type": 3
+        },
+        {
+          "type": 0
+        }
+      ]
+    },
+    "name": "OPPO Enco R4",
+    "id": "06AC50",
+    "type": "T2",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 15006000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154529,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0,
+          "defaultFunction": 262144
+        }
+      ],
+      "holdInBoxPairing": 1,
+      "batteryInfo": 1,
+      "promptVolume": 1,
+      "openBoxPairing": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 3,
+      "controlGuideSupport": 1,
+      "multiDevicesConnect": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 22,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 31,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 32,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "aiTranslate": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Buds3",
+    "id": "06A450",
+    "type": "T2",
+    "supportSpp": true,
+    "brand": "oppo",
+    "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"
+  },
+  {
+    "rssi": {
+      "rightOffset": 0,
+      "leftOffset": 0,
+      "secondRssi": 50,
+      "firstRssi": 50,
+      "flattenOffset": 0
+    },
+    "minVersion": 15006000,
+    "function": {
+      "dolbyAtmos": 1,
+      "spatialDescriptionType": 2,
+      "autoFirmwareUpdate": 1,
+      "customDress": 1,
+      "control": [
+        {
+          "ear": 2,
+          "action": 1,
+          "support": 516,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 2,
+          "support": 8805,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 3,
+          "support": 3154529,
+          "showEar": 0
+        },
+        {
+          "ear": 2,
+          "action": 6,
+          "support": 536,
+          "showEar": 0
+        }
+      ],
+      "callControl": [
+        {
+          "ear": 2,
+          "action": 29,
+          "support": 524800,
+          "showEar": 0,
+          "defaultFunction": 524288
+        },
+        {
+          "ear": 2,
+          "action": 31,
+          "support": 262656,
+          "showEar": 0,
+          "defaultFunction": 262144
+        }
+      ],
+      "holdInBoxPairing": 1,
+      "batteryInfo": 1,
+      "promptVolume": 1,
+      "openBoxPairing": 1,
+      "fastDiscovery": 1,
+      "related": 1,
+      "equalizer": 3,
+      "controlGuideSupport": 1,
+      "multiDevicesConnect": 1,
+      "spatialTypes": [
+        0,
+        1
+      ],
+      "equalizerMode": [
+        {
+          "modeType": 22,
+          "protocolIndex": 0
+        },
+        {
+          "modeType": 31,
+          "protocolIndex": 2
+        },
+        {
+          "modeType": 32,
+          "protocolIndex": 1
+        }
+      ],
+      "findDevice": 1,
+      "diagnostic": 1,
+      "aiTranslate": 1,
+      "clickTakePic": 1
+    },
+    "name": "OPPO Enco Air4（新声版）",
+    "id": "06B050",
+    "type": "T2",
     "supportSpp": true,
     "brand": "oppo",
     "uuid": "0000079A-D102-11E1-9B23-00025B00A5A5"


### PR DESCRIPTION
上个版本的json提交错了，那是我测试版的文件，实际上这才是真正要使用的版本。

正因如此，我把选择栏删除了，因为137个设备几乎不太可能由用户选择了（除非设计一个搜索框），这个json里的内容是由oppo网络下发的，可随版本更新


我认为支持列表可以更改了，几乎所有设备都在里面（虽然大多没有实测）